### PR TITLE
Version bumps for hygiene :: L4T 32.4.3 + RealSense 2.36.0 + Python 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ $ ./buildLibrealsense.sh
 <h2>Notes</h2>
 If you use realsense-ros, make sure that you match the librealsense versions with the realsense-ros version requirement.
 
+
+<h4>August, 2020</h4>
+
+* Release vL4T32.4.3
+* Jetson Nano
+* L4T 32.4.3, JetPack 4.4, Kernel 4.9.
+* Current  librealsense version v2.36.0
+* Now buildLibrealsense will install bindings for Python 3
+
 <h4>December, 2019</h4>
 
 * Release vL4T32.3.1

--- a/buildLibrealsense.sh
+++ b/buildLibrealsense.sh
@@ -3,12 +3,12 @@
 # Copyright (c) 2016-19 Jetsonhacks 
 # MIT License
 
-# Jetson Nano; L4T 32.2.3
+# Jetson Nano; L4T 32.4.3
 
 LIBREALSENSE_DIRECTORY=${HOME}/librealsense
-LIBREALSENSE_VERSION=v2.31.0
+LIBREALSENSE_VERSION=v2.36.0
 INSTALL_DIR=$PWD
-NVCC_PATH=/usr/local/cuda-10.0/bin/nvcc
+NVCC_PATH=/usr/local/cuda-10.2/bin/nvcc
 
 USE_CUDA=true
 
@@ -87,10 +87,11 @@ cd build
 echo "${green}Configuring Make system${reset}"
 # Build with CUDA (default), the CUDA flag is USE_CUDA, ie -DUSE_CUDA=true
 export CUDACXX=$NVCC_PATH
+export CMAKE_CUDA_COMPILER=$NVCC_PATH
 export PATH=${PATH}:/usr/local/cuda/bin
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/cuda/lib64
 
-/usr/bin/cmake ../ -DBUILD_EXAMPLES=true -DFORCE_LIBUVC=true -DBUILD_WITH_CUDA="$USE_CUDA" -DCMAKE_BUILD_TYPE=release -DBUILD_PYTHON_BINDINGS=bool:true
+/usr/bin/cmake ../ -DBUILD_EXAMPLES=true -DFORCE_LIBUVC=true -DBUILD_WITH_CUDA="$USE_CUDA" -DCMAKE_BUILD_TYPE=release -DBUILD_PYTHON_BINDINGS=bool:true -DPYTHON_EXECUTABLE=/usr/bin/python3
 
 # The library will be installed in /usr/local/lib, header files in /usr/local/include
 # The demos, tutorials and tests will located in /usr/local/bin.


### PR DESCRIPTION
**Description**
Updated scripts to deal with latest version bumps.

> L4T 32.4.3
> RealSense SDK 2.36.0
> Python 3

**Other information**
These changes are tested on Jetson Nano (fresh burn from L4T 32.4.3 JetPack 4.4).

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
